### PR TITLE
Canvas / Display.setParent() : it was not displaying correctly upon crea...

### DIFF
--- a/src/java/org/lwjgl/opengl/MacOSXCanvasPeerInfo.java
+++ b/src/java/org/lwjgl/opengl/MacOSXCanvasPeerInfo.java
@@ -38,145 +38,149 @@ import java.awt.Insets;
 import java.awt.Container;
 import java.awt.Component;
 import java.awt.Point;
-import java.awt.Window;
 import java.nio.ByteBuffer;
 
 import javax.swing.SwingUtilities;
 
 import org.lwjgl.LWJGLException;
-import org.lwjgl.LWJGLUtil;
 
 /**
  *
  * @author elias_naur <elias_naur@users.sourceforge.net>
  * @author kappaOne <one.kappa@gmail.com>
- * @version $Revision$
- * $Id$
+ * @version $Revision$ $Id$
  */
 abstract class MacOSXCanvasPeerInfo extends MacOSXPeerInfo {
-	private final AWTSurfaceLock awt_surface = new AWTSurfaceLock();
-	public ByteBuffer window_handle;
-	
-	protected MacOSXCanvasPeerInfo(PixelFormat pixel_format, ContextAttribs attribs, boolean support_pbuffer) throws LWJGLException {
-		super(pixel_format, attribs, true, true, support_pbuffer, true);
-	}
 
-	protected void initHandle(Canvas component) throws LWJGLException {
-		boolean forceCALayer = true;
-		boolean autoResizable = true; // set the CALayer to autoResize
-		
-		String javaVersion = System.getProperty("java.version");
-		
-		if (javaVersion.startsWith("1.5") || javaVersion.startsWith("1.6")) {
+        private final AWTSurfaceLock awt_surface = new AWTSurfaceLock();
+        public ByteBuffer window_handle;
+
+        protected MacOSXCanvasPeerInfo(PixelFormat pixel_format, ContextAttribs attribs, boolean support_pbuffer) throws LWJGLException {
+                super(pixel_format, attribs, true, true, support_pbuffer, true);
+        }
+
+        protected void initHandle(Canvas component) throws LWJGLException {
+                boolean forceCALayer = true;
+                boolean autoResizable = true; // set the CALayer to autoResize
+
+                String javaVersion = System.getProperty("java.version");
+
+                if (javaVersion.startsWith("1.5") || javaVersion.startsWith("1.6")) {
 			// On Java 7 and newer CALayer mode is the only way to use OpenGL with AWT
-			// therefore force it on all JVM's except for the older Java 5 and Java 6
-			// where the older cocoaViewRef NSView method maybe be available.
-			forceCALayer = false;
-		}
-		else if (javaVersion.startsWith("1.7")) {
-			autoResizable = false;
-		}
-		
-		Insets insets = getInsets(component);
-		
-		int top = insets != null ? insets.top : 0;
-		int left = insets != null ? insets.left : 0;
-		
-		window_handle = nInitHandle(awt_surface.lockAndGetHandle(component), getHandle(), window_handle, forceCALayer, autoResizable, component.getX()-left, component.getY()-top);
-		
-		if (javaVersion.startsWith("1.7")) {
+                        // therefore force it on all JVM's except for the older Java 5 and Java 6
+                        // where the older cocoaViewRef NSView method maybe be available.
+                        forceCALayer = false;
+                } // fix for CALayer position not covering Canvas due to a Java 7 bug (don't autoresize, use componentlistener)
+                else if (javaVersion.startsWith("1.7")) {
+                        autoResizable = false;
+                }
+
+                Insets insets = getInsets(component);
+
+                int top = insets != null ? insets.top : 0;
+                int left = insets != null ? insets.left : 0;
+                
+                // get Root position of the Canvas for Quartz layout.
+                Component peer = SwingUtilities.getRoot(component);                
+                Point rtLoc = SwingUtilities.convertPoint(component.getParent(), component.getLocation(), peer);
+
+                // reverse oY
+                window_handle = nInitHandle(awt_surface.lockAndGetHandle(component), getHandle(), window_handle, forceCALayer, autoResizable, rtLoc.x - left, peer.getHeight() - rtLoc.y + top - component.getHeight());
+
+                if (javaVersion.startsWith("1.7")) {
 			// fix for CALayer position not covering Canvas due to a Java 7 bug
-			// http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7172187
-			addComponentListener(component);
-					
+                        // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7172187
+                        addComponentListener(component);
+
                         reSetLayerBounds(component, getHandle());
-		}
-	}
-	
-	private void addComponentListener(final Canvas component) {
-		
-		ComponentListener[] components = component.getComponentListeners();
-		
-		// avoid adding duplicate listners by checking if one has already been added
-		for (int i = 0; i < components.length; i++) {
-			ComponentListener c = components[i];
-			if (c.toString() == "CanvasPeerInfoListener") {
-				return; // already contains the listner below return without adding
-			}
-		}
-		
-		ComponentListener comp = new ComponentListener() {
-			public void componentHidden(ComponentEvent e) {
-				
-			}
+                }
+        }
 
-			public void componentMoved(ComponentEvent e) {
-				
-				//nSetLayerPosition(getHandle(), component.getX() - left, component.getY() - top);
-				reSetLayerBounds(component, getHandle());
-			}
+        private void addComponentListener(final Canvas component) {
 
-			public void componentResized(ComponentEvent e) {
-				
-				//nSetLayerPosition(getHandle(), component.getX() - left, component.getY() - top);
-				reSetLayerBounds(component, getHandle());
-			}
+                ComponentListener[] components = component.getComponentListeners();
 
-			public void componentShown(ComponentEvent e) {
-				
-			}
-			
-			public String toString() {
-				return "CanvasPeerInfoListener";
-			}
-		};
-		
-		component.addComponentListener(comp);
-	}
-	
-	private static native ByteBuffer nInitHandle(ByteBuffer surface_buffer, ByteBuffer peer_info_handle, ByteBuffer window_handle, boolean forceCALayer, boolean autoResizable, int x, int y) throws LWJGLException;
+                // avoid adding duplicate listners by checking if one has already been added
+                for (int i = 0; i < components.length; i++) {
+                        ComponentListener c = components[i];
+                        if (c.toString() == "CanvasPeerInfoListener") {
+                                return; // already contains the listner below return without adding
+                        }
+                }
 
-	private static native void nSetLayerPosition(ByteBuffer peer_info_handle, int x, int y);
-	
-	private static native void nSetLayerBounds(ByteBuffer peer_info_handle, int x, int y, int width, int height);
-	
+                ComponentListener comp = new ComponentListener() {
+                        public void componentHidden(ComponentEvent e) {
+
+                        }
+
+                        public void componentMoved(ComponentEvent e) {
+
+                                //nSetLayerPosition(getHandle(), component.getX() - left, component.getY() - top);
+                                reSetLayerBounds(component, getHandle());
+                        }
+
+                        public void componentResized(ComponentEvent e) {
+
+                                //nSetLayerPosition(getHandle(), component.getX() - left, component.getY() - top);
+                                reSetLayerBounds(component, getHandle());
+                        }
+
+                        public void componentShown(ComponentEvent e) {
+
+                        }
+
+                        public String toString() {
+                                return "CanvasPeerInfoListener";
+                        }
+                };
+
+                component.addComponentListener(comp);
+        }
+
+        private static native ByteBuffer nInitHandle(ByteBuffer surface_buffer, ByteBuffer peer_info_handle, ByteBuffer window_handle, boolean forceCALayer, boolean autoResizable, int x, int y) throws LWJGLException;
+
+        private static native void nSetLayerPosition(ByteBuffer peer_info_handle, int x, int y);
+
+        private static native void nSetLayerBounds(ByteBuffer peer_info_handle, int x, int y, int width, int height);
+
         /**
          * fix for CALayer position not covering Canvas due to a Java 7 bug
          * {@link http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7172187}
+         *
          * @param component
-         * @param peer_info_handle 
+         * @param peer_info_handle
          */
         private static void reSetLayerBounds(Canvas component, ByteBuffer peer_info_handle) {
                 // report the root parent (peer).
                 Component peer = SwingUtilities.getRoot(component);
-                
+
                 Point rtLoc = SwingUtilities.convertPoint(component.getParent(), component.getLocation(), peer);
                 int x = (int) rtLoc.getX(), y = (int) rtLoc.getY();
-                
+
                 Insets insets = getInsets(component);
                 x -= insets != null ? insets.left : 0;
                 y -= insets != null ? insets.top : 0;
-                
+
                 // http://hg.openjdk.java.net/jdk8/awt/jdk/rev/65d874d16d59
                 y = (int) peer.getHeight() - y - (int) component.getHeight();
 
                 nSetLayerBounds(peer_info_handle, x, y, component.getWidth(), component.getHeight());
         }
-        
-	protected void doUnlock() throws LWJGLException {
-		awt_surface.unlock();
-	}
-	
+
+        protected void doUnlock() throws LWJGLException {
+                awt_surface.unlock();
+        }
+
         /**
          * @return rootpane insets (peer insets) values.
          */
-	private static Insets getInsets(Canvas component) {
-		Container c = SwingUtilities.getRootPane(component);
-                
-                if(c != null) {
+        private static Insets getInsets(Canvas component) {
+                Container c = SwingUtilities.getRootPane(component);
+
+                if (c != null) {
                         return c.getInsets();
                 } else {
                         return new Insets(0, 0, 0, 0);
-                }                
-	}
+                }
+        }
 }

--- a/src/java/org/lwjgl/opengl/MacOSXMouseEventQueue.java
+++ b/src/java/org/lwjgl/opengl/MacOSXMouseEventQueue.java
@@ -99,8 +99,8 @@ final class MacOSXMouseEventQueue extends MouseEventQueue {
 		if (isGrabbed()) {
 			Rectangle bounds = getComponent().getBounds();
 			Point location_on_screen = getComponent().getLocationOnScreen();
-			int x = location_on_screen.x + bounds.width/2;
-			int y = location_on_screen.y + bounds.height/2;
+			int x = Math.round(location_on_screen.x + bounds.width/2f);
+			int y = Math.round(location_on_screen.y + bounds.height/2f);
 			nWarpCursor(x, y);
 		}
 	}

--- a/src/native/macosx/context.h
+++ b/src/native/macosx/context.h
@@ -113,12 +113,12 @@ typedef struct {
 - (NSOpenGLPixelFormat*)pixelFormat;
 - (void)setParent:(MacOSXWindowInfo*)parent;
 - (BOOL)acceptsFirstResponder;
+- (NSRect)getBoundsHighDpi;
 @end
 
 @interface GLLayer : CAOpenGLLayer {
 	@public
 	JAWT_MacOSXDrawingSurfaceInfo *macosx_dsi;
-	JAWT_Rectangle canvasBounds;
 	MacOSXWindowInfo *window_info;
 	bool setViewport;
 	bool autoResizable;


### PR DESCRIPTION
...te / destroy / create subsequent calls.
- overlapping canvas issue
- JVM NPE upon Display.destroy() ...
- context bounds (hi-dpi)
  These are fixed issues now.
